### PR TITLE
suggesting a more optimal repeat implementation

### DIFF
--- a/repeat.js
+++ b/repeat.js
@@ -16,9 +16,18 @@ if (!String.prototype.repeat) {
 			if (n < 0 || n == Infinity) {
 				throw RangeError();
 			}
-			var result = '';
-			while (n--) {
-				result += string;
+			if (n == 0) {
+				return '';
+			}
+			var result = string, reps = 1;
+			--n;
+			while (n >= reps) {
+				result += result;
+				n -= reps;
+				reps *= 2;
+			}
+			if (n > 0) {
+				result += result.substring(0, n * string.length);
 			}
 			return result;
 		};


### PR DESCRIPTION
see http://jsperf.com/string-prototype-repeat-polyfill for benchmarks

Basically, say you want to repeat a short string many times. The current implementation creates many intermediate strings, appending the short string to the result over and over. This PR optimizes a little bit by doubling the result as many times as possible (presumably leveraging the browser's optimization of string allocation).

You can see from the jsPerf that—at least on Chrome and Firefox (on my PC)—the performance is about the same for small values of N and significantly better for large values.
