### PR TITLE
only perform final string += string if necessary

### DIFF
--- a/repeat.js
+++ b/repeat.js
@@ -21,7 +21,9 @@ if (!String.prototype.repeat) {
 				if (n % 2 == 1) {
 					result += string;
 				}
-				string += string;
+				if (n > 1) {
+					string += string;
+				}
 				n >>= 1;
 			}
 			return result;


### PR DESCRIPTION
This avoids a superfluous string allocation in all cases where n > 1.
